### PR TITLE
Update list.twig

### DIFF
--- a/app/templates/bookshelf/author/list.twig
+++ b/app/templates/bookshelf/author/list.twig
@@ -8,7 +8,7 @@
 
 <ul>
 {% for author in authors %}
-    <li><a href="{{base_url()}}{{ path_for('author', {author_id: author.id}) }}">{{ author.name }}</a></li>
+    <li><a href="{{ path_for('author', {author_id: author.id}) }}">{{ author.name }}</a></li>
 {% endfor %}
 </ul>
 {% endblock %}


### PR DESCRIPTION
With twig-view 1.1 the base_url would double up the url and cause the link not to work
