### PR TITLE
Update layout.twig

### DIFF
--- a/app/templates/layout.twig
+++ b/app/templates/layout.twig
@@ -7,9 +7,9 @@
 
     <title>{% block title %}{% endblock %} &ndash; Bookshelf</title>
 
-    <link rel="stylesheet" href="{{ base_url() }}/css/bootstrap.min.css">
-    <link rel="stylesheet" href="{{ base_url() }}/css/bootstrap-theme.min.css">
-    <link rel="stylesheet" href="{{ base_url() }}/css/style.css">
+    <link rel="stylesheet" href="{{ path_for('list-authors') }}css/bootstrap.min.css">
+    <link rel="stylesheet" href="{{ path_for('list-authors') }}css/bootstrap-theme.min.css">
+    <link rel="stylesheet" href="{{ path_for('list-authors') }}css/style.css">
     <!--[if lt IE 9]>
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>


### PR DESCRIPTION
base_url would produce the wrong url when click on any link other than the root, with path_for it will work no matter which link you click.

This due to the base_url changes base on where it is at not the true "root" of the base_url
